### PR TITLE
Fixed GMail new email notifications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Dependency Troubleshooting
 ==========================
 TODO
 
+Link explainin how to fix the missing: `vcvarsall.bat` file: [Fix](http://stackoverflow.com/questions/2667069/cannot-find-vcvarsall-bat-when-running-a-python-script)
+Summary:
+You need to create a variable called: `VS90COMNTOOLS` that has the contents of `VS100COMNTOOLS`
+
 Running Digsby
 ==============
 `python Digsby.py`

--- a/digsby/src/plugins/component_gmail/gmail.py
+++ b/digsby/src/plugins/component_gmail/gmail.py
@@ -38,9 +38,14 @@ class Gmail(EmailAccount):
 
     protocol = 'gmail'
 
+    # TODO: these variables are all used, but it's unclear if
+    # they should all be from the same domain (https://accounts.google.com).
+    # Need to audit them and see what's up.
     baseAuthUrl  = 'https://www.google.com'
     authUrl  = '/accounts/ClientAuth'
     tokenUrl = '/accounts/IssueAuthToken'
+
+    tokenAuthUrl = 'https://accounts.google.com/TokenAuth'
 
     messageIdMatcher  = re.compile(r'message_id=([a-z0-9]+?)&')
     jsredirectMatcher = re.compile('location\.replace\("(.*)"\)')
@@ -175,7 +180,7 @@ class Gmail(EmailAccount):
         if self.web_login:
             self.new_token(internal=False)
         if self.web_login and self.external_token:
-            return UrlQuery('https://accounts.google.com/TokenAuth?',
+            return UrlQuery(self.tokenAuthUrl,
                     **{'auth':self.external_token,
                        'service':'mail',
                        'continue':url,
@@ -256,7 +261,7 @@ class Gmail(EmailAccount):
         if not token:
             return False
 
-        webreq_result = self.webrequest(UrlQuery('https://accounts.google.com/TokenAuth?',
+        webreq_result = self.webrequest(UrlQuery(self.tokenAuthUrl,
                                                  **{'auth':token,
                                                     'service':'mail',
                                                     'continue':self.internalBaseMailUrl,

--- a/digsby/src/plugins/component_gmail/gmail.py
+++ b/digsby/src/plugins/component_gmail/gmail.py
@@ -175,7 +175,7 @@ class Gmail(EmailAccount):
         if self.web_login:
             self.new_token(internal=False)
         if self.web_login and self.external_token:
-            return UrlQuery('https://www.google.com/accounts/TokenAuth?',
+            return UrlQuery('https://accounts.google.com/TokenAuth?',
                     **{'auth':self.external_token,
                        'service':'mail',
                        'continue':url,
@@ -256,7 +256,7 @@ class Gmail(EmailAccount):
         if not token:
             return False
 
-        webreq_result = self.webrequest(UrlQuery('https://www.google.com/accounts/TokenAuth?',
+        webreq_result = self.webrequest(UrlQuery('https://accounts.google.com/TokenAuth?',
                                                  **{'auth':token,
                                                     'service':'mail',
                                                     'continue':self.internalBaseMailUrl,


### PR DESCRIPTION
Fixed the linked that was used to get the Auth Cookie from Google.

Now notifications are working again. However the entire auth module is
outdated and should be migrated to OAuth2.
